### PR TITLE
Drop MacroTools dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,18 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
-          - macos-latest
         arch:
           - x64
+        include:
+          - os: windows-latest
+            version: '1'
+            arch: x86
+          - os: macos-latest
+            version: '1'
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           - os: windows-latest
             version: '1'
             arch: x86
-          - os: macos-latest
+          - os: macOS-latest
             version: '1'
             arch: x86
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,6 @@ jobs:
           - os: windows-latest
             version: '1'
             arch: x86
-          - os: macOS-latest
-            version: '1'
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,5 @@ uuid = "7044eba9-3226-4c27-acf2-f557c1cd82a0"
 authors = ["Rik Huijzer <rikhuijzer@pm.me>"]
 version = "1.0.1"
 
-[deps]
-MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-
 [compat]
-MacroTools = "0.5.9"
 julia = "1.6"

--- a/src/PrecompileMacro.jl
+++ b/src/PrecompileMacro.jl
@@ -1,25 +1,32 @@
 module PrecompileMacro
 
-using MacroTools: combinedef, splitarg, splitdef
-
 export @precompile
 
-"""
-Return tuple of types which can be passed as `args` into `precompile(f, args)`.
-"""
-function _types_tuple(def_dict)::Tuple{Vararg{Any}}
-    splitted = map(splitarg, def_dict[:args])
-    typesyms = Tuple(tup[2] for tup in splitted)::Tuple{Vararg{Symbol}}
-    # Convert, for example, `(:String, :Int)` to `(String, Int)`.
-    types = eval.(typesyms)
-    if !all(isconcretetype.(collect(types)))
+function _precompile(func::Expr)
+    func.args[1].head == :where && error("@precompile is not implemented for methods with type parameters")
+
+    sig = func.args[1].args
+    func_name = sig[1]::Symbol
+    # Drop function name and kwargs.
+    args = filter(x -> x isa Expr && x.head != :parameters, sig)
+    types = Tuple(eval(last(arg.args)) for arg in args)
+    if !all(isconcretetype.(types))
         nonconcrete = filter(!isconcretetype, types)
-        mult = 1 < length(nonconcrete)
-        msg = "The type$(mult ? 's' : "") $nonconcrete in the signature $types $(mult ? "are" : "is") not concrete."
+        multiple = 1 < length(nonconcrete)
+        msg = "The type$(multiple ? 's' : "") $nonconcrete in the signature $(func_name)$(types) $(multiple ? "are" : "is") not concrete."
         error(msg)
     end
-    return types
+
+    precompile_ex = :(precompile($func_name, $types))
+
+    # Note that `precompile` returns a boolean to indicate whether a statement is active.
+    # Might be useful at some point.
+    return esc(quote
+        Base.@__doc__($func)
+        $precompile_ex
+    end)
 end
+precompile(_precompile, (Expr,))
 
 """
     @precompile(func)
@@ -28,22 +35,7 @@ Define function `func` and define a precompile statement for `func`, see `precom
 Return whether a precompile statement is active.
 """
 macro precompile(func)
-    def_dict = try
-        splitdef(func)
-    catch
-        error("@precompile must be applied to a method definition")
-    end
-
-    name = def_dict[:name]
-    precompile_args = _types_tuple(def_dict)
-    precompile_ex = :(precompile($name, $precompile_args))
-
-    # Note that `precompile` returns a boolean to indicate whether a statement is active.
-    # Might be useful at some point.
-    return esc(quote
-        Base.@__doc__($func)
-        $precompile_ex
-    end)
+    return _precompile(func)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,13 @@ using Test
     # To be sure that the method works.
     @test g("lorem", 1) == "lorem1"
 
+    @precompile h(a::Int, b::Int; c=3) = string(a, b, c)
+    @test length(methodinstances(h)) == 1
+
     @test_throws LoadError eval(:(@precompile f(path::AbstractString) = 1))
 
     "Some doc"
-    @precompile h() = 3
-    @test length(methodinstances(h)) == 1
-    @test contains(string(@doc h), "Some doc")
+    @precompile k() = 3
+    @test length(methodinstances(k)) == 1
+    @test contains(string(@doc k), "Some doc")
 end


### PR DESCRIPTION
Avoiding the dependency seems like a good idea since it is fairly straightforward to implement here. Also, having this implementation here allows for more optimizations.

Dropping it doesn't seem to affect performance on Julia 1.7.2:

## master

```julia
julia> @time using PrecompileMacro
  0.765824 seconds (611.35 k allocations: 33.541 MiB, 3.44% gc time, 96.21% compilation time)

julia> @time @precompile f() = 3
  0.024938 seconds (33.79 k allocations: 1.939 MiB, 99.43% compilation time)
```

## this PR

```julia
julia> @time using PrecompileMacro
  0.784445 seconds (619.39 k allocations: 33.726 MiB, 96.47% compilation time)

julia> @time @precompile f() = 3
  0.023438 seconds (33.79 k allocations: 1.952 MiB, 99.18% compilation time)
```